### PR TITLE
Update kube-watch scripts to support kubernetes >= 1.7 and to take advantage of RBAC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,11 +148,13 @@ define generate-rbac-rolebinding
 endef
 
 deploy-rbac:
+	if [ -z "$(RBAC_API_VERSION)" ]; then exit 1; fi
 	kubectl apply -f kube/rbac/serviceaccount.yml
 	$(call generate-rbac-role) | kubectl apply -f -
 	$(call generate-rbac-rolebinding) | kubectl apply -f -
 
 clean-rbac:
+	if [ -z "$(RBAC_API_VERSION)" ]; then exit 1; fi
 	kubectl delete serviceaccount graphite-cluster-sa || true
 	kubectl delete rolebinding read-endpoints || true
 	kubectl delete role endpoints-reader || true

--- a/docker/carbon-relay/Dockerfile
+++ b/docker/carbon-relay/Dockerfile
@@ -25,7 +25,7 @@ add conf/storage-schemas.conf /opt/graphite/conf/storage-schemas.conf
 add	./supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 RUN mkdir /kube-watch
-RUN cd /kube-watch && npm install hashring kubernetes-client@3.18.1 json-stream
+RUN cd /kube-watch && npm install hashring kubernetes-client@5 json-stream
 add kube-watch.js /kube-watch/kube-watch.js
 
 EXPOSE 2003

--- a/docker/graphite-master/Dockerfile
+++ b/docker/graphite-master/Dockerfile
@@ -50,7 +50,7 @@ run	chmod 0664 /opt/graphite/storage/graphite.db
 run cp /src/graphite-web/webapp/manage.py /opt/graphite/webapp
 
 RUN mkdir /kube-watch
-RUN cd /kube-watch && npm install hashring kubernetes-client@3.18.1 json-stream
+RUN cd /kube-watch && npm install hashring kubernetes-client@5 json-stream
 add kube-watch.js /kube-watch/kube-watch.js
 
 add entrypoint.sh /entrypoint.sh

--- a/docker/graphite-master/Dockerfile
+++ b/docker/graphite-master/Dockerfile
@@ -29,6 +29,10 @@ RUN     git clone https://github.com/graphite-project/graphite-web.git /src/grap
         pip install -r requirements.txt                                                   &&\
         python check-dependencies.py
 
+# fixes fatal error "Your WhiteNoise configuration is incompatible with WhiteNoise v4.0"
+RUN     /usr/bin/yes | pip uninstall whitenoise                                           &&\
+        pip install "whitenoise<4"
+
 # Add system service config
 add	./nginx/nginx.conf /etc/nginx/nginx.conf
 add	./supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/docker/graphite-master/kube-watch.js
+++ b/docker/graphite-master/kube-watch.js
@@ -1,44 +1,53 @@
-const util = require('util');
-const fs = require('fs')
-const Api = require('kubernetes-client');
-const kube = new Api.Core(Api.config.getInCluster());
+const fs = require('fs');
+const Client = require('kubernetes-client').Client;
+const config = require('kubernetes-client').config;
+const client = new Client({ config: config.getInCluster() });
 const JSONStream = require('json-stream');
 const jsonStream = new JSONStream();
-const configFileTemplate="/opt/graphite/webapp/graphite/local_settings.py.template";
-const configFileTarget="/opt/graphite/webapp/graphite/local_settings.py";
-const processToRestart="graphite-webapp"
+const configFileTemplate = "/opt/graphite/webapp/graphite/local_settings.py.template";
+const configFileTarget = "/opt/graphite/webapp/graphite/local_settings.py";
+const processToRestart = "graphite-webapp"
 const configTemplate = fs.readFileSync(configFileTemplate, 'utf8');
 const exec = require('child_process').exec;
+const namespace = fs.readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/namespace', 'utf8').toString();
 
 function restartProcess() {
   exec(`supervisorctl restart ${processToRestart}`, (error, stdout, stderr) => {
-    console.log(`out: ${stdout}
-      err: ${stderr}`)})
+    if (error) {
+      console.error(error);
+      return;
+    }
+    console.log(stdout);
+    console.error(stderr);
+  });
 }
 
 function getNodes(endpoints) {
-  if (endpoints.subsets.length > 0) {
-    return endpoints.subsets[0].addresses.map(e => `"${(e.ip + ':80')}"`).join(",");
-  } else {
-    return "";
-  }
+  return endpoints.subsets ? endpoints.subsets[0].addresses.map(e => `"${e.ip}:80"`).join(",") : "";
 }
 
 function changeConfig(endpoints) {
   var result = configTemplate.replace(/@@GRAPHITE_NODES@@/g, getNodes(endpoints));
   fs.writeFileSync(configFileTarget, result);
-  restartProcess()
+  restartProcess();
 }
 
-kube.ns.endpoints.get('graphite-node', function(err, result) {
-  console.log(JSON.stringify(result))
-  changeConfig(result)
-})
+async function main() {
+  await client.loadSpec();
+  const stream = client.apis.v1.ns(namespace).endpoints.getStream({ qs: { watch: true, fieldSelector: 'metadata.name=graphite-node' } });
+  stream.pipe(jsonStream);
+  jsonStream.on('data', obj => {
+    if (!obj) {
+      return;
+    }
+    console.log('Received update:', JSON.stringify(obj));
+    changeConfig(obj.object);
+  });
+}
 
-const stream = kube.endpoints.get({qs: {watch: true, fieldSelector: 'metadata.name=graphite-node'}})
-stream.pipe(jsonStream);
-jsonStream.on('data', obj => {
-  console.log('Received update:', JSON.stringify(obj, null, 2));
-  changeConfig(obj.object);
-});
-
+try {
+  main();
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}

--- a/docker/graphite-node/Dockerfile
+++ b/docker/graphite-node/Dockerfile
@@ -27,6 +27,10 @@ RUN     git clone https://github.com/graphite-project/graphite-web.git /src/grap
         pip install -r requirements.txt                                                   &&\
         python check-dependencies.py
 
+# fixes fatal error "Your WhiteNoise configuration is incompatible with WhiteNoise v4.0"
+RUN     /usr/bin/yes | pip uninstall whitenoise                                           &&\
+        pip install "whitenoise<4"
+
 # Add system service config
 add	./nginx/nginx.conf /etc/nginx/nginx.conf
 add	./supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/docker/statsd-proxy/Dockerfile
+++ b/docker/statsd-proxy/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN git clone https://github.com/etsy/statsd.git
 WORKDIR /app/statsd
 RUN npm install -g forever
-RUN npm install hashring kubernetes-client@3.18.1 json-stream --save
+RUN npm install hashring kubernetes-client@5 json-stream --save
 COPY * ./
 
 EXPOSE 8125/udp 8126

--- a/kube/carbon-relay/dep.yml
+++ b/kube/carbon-relay/dep.yml
@@ -20,4 +20,5 @@ spec:
           - containerPort: 2004
             name: pickle
             protocol: TCP
+      serviceAccountName: graphite-cluster-sa
       {{ADDITIONAL_YAML}}

--- a/kube/graphite-master/dep.yml
+++ b/kube/graphite-master/dep.yml
@@ -21,3 +21,4 @@ spec:
           - containerPort: 80
             name: http
             protocol: TCP
+      serviceAccountName: graphite-cluster-sa

--- a/kube/rbac/role-binding.yml
+++ b/kube/rbac/role-binding.yml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-endpoints
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: endpoints-reader
+subjects:
+- kind: ServiceAccount
+  name: graphite-cluster-sa

--- a/kube/rbac/role-binding.yml
+++ b/kube/rbac/role-binding.yml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{RBAC_API_VERSION}}
 kind: RoleBinding
 metadata:
   name: read-endpoints

--- a/kube/rbac/role.yml
+++ b/kube/rbac/role.yml
@@ -1,5 +1,5 @@
+apiVersion: {{RBAC_API_VERSION}}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: endpoints-reader
 rules:

--- a/kube/rbac/role.yml
+++ b/kube/rbac/role.yml
@@ -1,0 +1,8 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: endpoints-reader
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get", "watch", "list"]

--- a/kube/rbac/serviceaccount.yml
+++ b/kube/rbac/serviceaccount.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: graphite-cluster-sa

--- a/kube/statsd-proxy/dep.yml
+++ b/kube/statsd-proxy/dep.yml
@@ -21,4 +21,5 @@ spec:
           - containerPort: 8125
             name: incoming-udp
             protocol: UDP
+      serviceAccountName: graphite-cluster-sa
       {{ADDITIONAL_YAML}}


### PR DESCRIPTION
This PR adds support to kubernetes >= 1.7 with RBAC and resolves issuse #21
It provides configuration files to deploy dedicated role and service account and updates the various kube-watch scripts to use the latest version of kubernetes-client.

**Breaking changes**
Due to kubernetes-client not supporting kubernetes < 1.7, this PR breaks the support to old versions